### PR TITLE
Update URL for cpt-city

### DIFF
--- a/tools/paletteknife/index.html
+++ b/tools/paletteknife/index.html
@@ -6,8 +6,8 @@
 
 <p>Then:
 <ol>
-<li>Go to CPT-CITY here, <a href="http://soliton.vm.bytemark.co.uk/pub/cpt-city/\" target=_new>http://soliton.vm.bytemark.co.uk/pub/cpt-city/</a>
-<li>Find a palette you like, e.g. <a href="http://soliton.vm.bytemark.co.uk/pub/cpt-city/rc/tn/purplefly.png.index.html" target=_new>http://soliton.vm.bytemark.co.uk/pub/cpt-city/rc/tn/purplefly.png.index.html</a>
+<li>Go to CPT-CITY here, <a href="http://seaviewsensing.com/pub/cpt-city/\" target=_new>http://seaviewsensing.com/pub/cpt-city/</a>
+<li>Find a palette you like, e.g. <a href="http://seaviewsensing.com/pub/cpt-city/rc/tn/purplefly.png.index.html" target=_new>http://seaviewsensing.com/pub/cpt-city/rc/tn/purplefly.png.index.html</a>
 <li>Click PaletteKnife in your toolbar,
 <li>Copy the resulting code and paste it into your FastLED project.
 <li>Relaxen und watchen das blinkenlights.

--- a/tools/paletteknife/pk2.js
+++ b/tools/paletteknife/pk2.js
@@ -41,15 +41,15 @@ function adjustGamma( orig, gamma)
 
 
 var origurl = document.location.href;
-//"http://soliton.vm.bytemark.co.uk/pub/cpt-city/dca/tn/alarm.p1.0.2.png.index.html";
+//"http://seaviewsensing.com/pub/cpt-city/dca/tn/alarm.p1.0.2.png.index.html";
 
 // origurl = //document.location.href;
 var url2 = origurl.replace( "/tn/", "/");
 var url3 = url2.replace( ".png.index.html", ".c3g");
 
-var onSite = url3.indexOf("http://soliton.vm.bytemark.co.uk/");
+var onSite = url3.indexOf("http://seaviewsensing.com/");
 if( onSite != 0) {
-    window.location.href="http://soliton.vm.bytemark.co.uk/pub/cpt-city/";
+    window.location.href="http://seaviewsensing.com/pub/cpt-city/";
     //return;
 }
 
@@ -187,7 +187,7 @@ if( onSite == 0) {
     i.src = url3;
     document.body.appendChild(i);
 } else {
-    window.location.href="http://soliton.vm.bytemark.co.uk/pub/cpt-city/";
+    window.location.href="http://seaviewsensing.com/pub/cpt-city/";
 }
 cursor_clear();
 //alert(stdout);


### PR DESCRIPTION
The original URL for cpt-city now redirects to a mirror of the site, but it only redirects to the base URL rather than the full pathname. This behaviour breaks paletteknife.

The changes here point paletteknife directly to the mirror, which resolves the problem for me.