### PR TITLE
Fix project sync workflow YAML formatting

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,1 +1,64 @@
-name: add-to-project  # Auto-adds every new issue / PR to the FastLED Tracker project (#1). # # Auth: GitHub App "FastLED Project Sync" — scoped to Projects: read/write + # Contents/Issues/Pull requests: read. No expiration (App installation tokens # auto-rotate). The App ID lives in a repo variable; the private key lives in # a repo secret. # # Required configuration (already set on all 6 feeder repos): #   vars.PROJECT_APP_CLIENT_ID      = Iv23liL4dLxjYFwTNWKt #   vars.PROJECT_OWNER            = FastLED #   vars.PROJECT_NUMBER           = 1 #   secrets.PROJECT_APP_PRIVATE_KEY = <PEM contents> # # To rotate the App's private key: #   1. On https://github.com/organizations/FastLED/settings/apps generate new key #   2. For each repo: gh secret set PROJECT_APP_PRIVATE_KEY --repo FastLED/<repo> < new.pem #   3. Revoke the old key in the App settings  on:   issues:     types: [opened]   pull_request:     types: [opened]  env:   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"  # pull_request (not pull_request_target) — fork PRs run in the fork's context # without access to PROJECT_APP_PRIVATE_KEY, so they simply won't be # auto-added. That is an intentional security trade-off: pull_request_target # would run with base-repo secrets against fork-authored metadata, which is a # known exfiltration vector even when no code is checked out. permissions:   contents: read   pull-requests: read  jobs:   add:     runs-on: ubuntu-latest     if: ${{ vars.PROJECT_APP_CLIENT_ID != '' && vars.PROJECT_OWNER != '' }}     steps:       - name: Generate App token         id: app-token         continue-on-error: true         uses: actions/create-github-app-token@v3         with:           client-id: ${{ vars.PROJECT_APP_CLIENT_ID }}           private-key: ${{ secrets.PROJECT_APP_PRIVATE_KEY }}           owner: ${{ vars.PROJECT_OWNER }}        - name: App not installed — skipping project sync         if: ${{ steps.app-token.outcome != 'success' }}         run: |           echo "::warning::FastLED Project Sync App is not installed on '${{ vars.PROJECT_OWNER }}'."           echo "::warning::Install it at https://github.com/organizations/${{ vars.PROJECT_OWNER }}/settings/installations to enable auto-add-to-project."        - name: Add to project         if: ${{ steps.app-token.outcome == 'success' }}         uses: actions/add-to-project@v1.0.2         with:           project-url: https://github.com/orgs/${{ vars.PROJECT_OWNER }}/projects/${{ vars.PROJECT_NUMBER }}           github-token: ${{ steps.app-token.outputs.token }}
+name: add-to-project
+
+# Auto-adds every new issue / PR to the FastLED Tracker project (#1).
+#
+# Auth: GitHub App "FastLED Project Sync" — scoped to Projects: read/write +
+# Contents/Issues/Pull requests: read. No expiration (App installation tokens
+# auto-rotate). The App ID lives in a repo variable; the private key lives in
+# a repo secret.
+#
+# Required configuration (already set on all 6 feeder repos):
+#   vars.PROJECT_APP_CLIENT_ID      = Iv23liL4dLxjYFwTNWKt
+#   vars.PROJECT_OWNER            = FastLED
+#   vars.PROJECT_NUMBER           = 1
+#   secrets.PROJECT_APP_PRIVATE_KEY = <PEM contents>
+#
+# To rotate the App's private key:
+#   1. On https://github.com/organizations/FastLED/settings/apps generate new key
+#   2. For each repo: gh secret set PROJECT_APP_PRIVATE_KEY --repo FastLED/<repo> < new.pem
+#   3. Revoke the old key in the App settings
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+# pull_request (not pull_request_target) — fork PRs run in the fork's context
+# without access to PROJECT_APP_PRIVATE_KEY, so they simply won't be
+# auto-added. That is an intentional security trade-off: pull_request_target
+# would run with base-repo secrets against fork-authored metadata, which is a
+# known exfiltration vector even when no code is checked out.
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  add:
+    runs-on: ubuntu-latest
+    if: ${{ vars.PROJECT_APP_CLIENT_ID != '' && vars.PROJECT_OWNER != '' }}
+    steps:
+      - name: Generate App token
+        id: app-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.PROJECT_APP_CLIENT_ID }}
+          private-key: ${{ secrets.PROJECT_APP_PRIVATE_KEY }}
+          owner: ${{ vars.PROJECT_OWNER }}
+
+      - name: App not installed — skipping project sync
+        if: ${{ steps.app-token.outcome != 'success' }}
+        run: |
+          echo "::warning::FastLED Project Sync App is not installed on '${{ vars.PROJECT_OWNER }}'."
+          echo "::warning::Install it at https://github.com/organizations/${{ vars.PROJECT_OWNER }}/settings/installations to enable auto-add-to-project."
+
+      - name: Add to project
+        if: ${{ steps.app-token.outcome == 'success' }}
+        uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/${{ vars.PROJECT_OWNER }}/projects/${{ vars.PROJECT_NUMBER }}
+          github-token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary
- restore newline-preserved YAML for `.github/workflows/add-to-project.yml`
- keep the hardened project-sync behavior from the prior PR

## Validation
- fetched the branch file after update to confirm it contains normal YAML line breaks